### PR TITLE
socketを用いたIPアドレス取得方式に変更。ip_tracerというAPI上で実現。

### DIFF
--- a/ip_tracer.py
+++ b/ip_tracer.py
@@ -1,0 +1,10 @@
+import socket
+
+def get_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    return s.getsockname()[0]
+
+if __name__ == "__main__":
+    ip = get_ip()
+    print(ip)

--- a/simpleserver.py
+++ b/simpleserver.py
@@ -10,6 +10,8 @@ from ipaddress import IPv6Address, IPv4Address
 import subprocess
 import sys
 
+from ip_tracer import get_ip
+
 import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -38,7 +40,7 @@ class HTTPServersHandle():
         if self.auto:
             if not ipv6 and not ipv4:
                 raise Exception("If you set auto mode you mast set True in ipv6 or ipv4")
-            ip_list = subprocess.getoutput("hostname -I").split(" ")
+            ip_list = [get_ip()]
             ip_list = [d for d in ip_list if d != ""]
             if ipv6:
                 for d in ip_list:


### PR DESCRIPTION
# 実施したこと
ip_tracerというAPI上にget_ip()を作成し、返り値としてデバイスに割り当てられたIPアドレスを設定。
これだと複数ネットワークに接続されたマシン上だとどのネットワーク上にサーバーが立ち上がるのか不明なので、選択できる様にしたい。

Closes #1 